### PR TITLE
Improve memory usage of textures

### DIFF
--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -41,7 +41,7 @@ class Texture(Loadable):
   384, 512, 576, 640, 720, 768, 800, 960, 1024, 1080, 1920
   """
   def __init__(self, file_string, blend=False, flip=False, size=0,
-               defer=DEFER_TEXTURE_LOADING, mipmap=True, m_repeat=False):
+               defer=DEFER_TEXTURE_LOADING, mipmap=True, m_repeat=False, free_after_load=False):
     """
     Arguments:
       *file_string*
@@ -70,6 +70,8 @@ class Texture(Loadable):
       *m_repeat*
         if the texture is repeated (see umult and vmult in Shape.set_draw_details)
         then this can be used to make a non-seamless texture tile
+      *free_after_load*
+        release image memory after loading it in opengl
     """
     super(Texture, self).__init__()
     try:
@@ -94,6 +96,7 @@ class Texture(Loadable):
     self.mipmap = mipmap
     self.m_repeat = GL_MIRRORED_REPEAT if m_repeat else GL_REPEAT
     self.byte_size = 0
+    self.free_after_load = free_after_load
     self._loaded = False
     if defer:
       self.load_disk()
@@ -218,6 +221,8 @@ class Texture(Loadable):
                              self.m_repeat)
     opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
                              self.m_repeat)
+    if self.free_after_load:
+        self.image = None
 
 
   def _unload_opengl(self):

--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -228,6 +228,7 @@ class Texture(Loadable):
                              self.m_repeat)
     if self.free_after_load:
         self.image = None
+        self._loaded = False
 
 
   def _unload_opengl(self):

--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -41,7 +41,8 @@ class Texture(Loadable):
   384, 512, 576, 640, 720, 768, 800, 960, 1024, 1080, 1920
   """
   def __init__(self, file_string, blend=False, flip=False, size=0,
-               defer=DEFER_TEXTURE_LOADING, mipmap=True, m_repeat=False, free_after_load=False):
+               defer=DEFER_TEXTURE_LOADING, mipmap=True, m_repeat=False,
+               free_after_load=False, i_format=None):
     """
     Arguments:
       *file_string*
@@ -72,6 +73,8 @@ class Texture(Loadable):
         then this can be used to make a non-seamless texture tile
       *free_after_load*
         release image memory after loading it in opengl
+      *i_format*
+        opengl internal format for the texture - see glTexImage2D
     """
     super(Texture, self).__init__()
     try:
@@ -97,6 +100,7 @@ class Texture(Loadable):
     self.m_repeat = GL_MIRRORED_REPEAT if m_repeat else GL_REPEAT
     self.byte_size = 0
     self.free_after_load = free_after_load
+    self.i_format = i_format
     self._loaded = False
     if defer:
       self.load_disk()
@@ -202,7 +206,8 @@ class Texture(Loadable):
       self.image = new_array
     opengles.glBindTexture(GL_TEXTURE_2D, self._tex)
     RGBv = GL_RGBA if self.alpha else GL_RGB
-    opengles.glTexImage2D(GL_TEXTURE_2D, 0, RGBv, self.ix, self.iy, 0, RGBv,
+    iformat = self.i_format if self.i_format else RGBv
+    opengles.glTexImage2D(GL_TEXTURE_2D, 0, iformat, self.ix, self.iy, 0, RGBv,
                           GL_UNSIGNED_BYTE,
                           self.image.ctypes.data_as(ctypes.POINTER(ctypes.c_short)))
     opengles.glEnable(GL_TEXTURE_2D)


### PR DESCRIPTION
Hi,

In our use case (a few big full color textures and some icons - basically partially transparent white shapes) we've seen that the memory usage for the textures is relatively high.

On one hand in the python Texture object the image loaded in a numpy array (stored in self.image) is never released, so unless the whole texture object is unreferenced this memory can't be freed.
I'm not sure if there is a way to release this memory in any other way.
I'm proposing to clear this var after the texture has been loaded into OpenGL. In the attached patch it is optional, as this could break pickling or unloading and reloading a textur to opengl and I'm not sure if this is something that would be desirable in all cases.

The other feature we'd like to do add is being able to change the internal OpenGL storage format.
With that we can cut down GPU memory usage in half for most of the textures by using GL_RGBA4.

Please let me know if this is ok for you and if not what I could change.
Thanks in advance!