### PR TITLE
Make dispmanx layer configurable for OpenGL display

### DIFF
--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -402,7 +402,7 @@ class Display(object):
 def create(x=None, y=None, w=None, h=None, near=None, far=None,
            fov=DEFAULT_FOV, depth=DEFAULT_DEPTH, background=None,
            tk=False, window_title='', window_parent=None, mouse=False,
-           frames_per_second=None, samples=DEFAULT_SAMPLES, use_pygame=False):
+           frames_per_second=None, samples=DEFAULT_SAMPLES, use_pygame=False, layer=0):
   """
   Creates a pi3d Display.
 
@@ -442,6 +442,8 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
     To use pygame for display surface, mouse and keyboard - as per windows
     This almost certainly would conflict if attempting to use in combination
     with tk=True. Default False
+  *layer*
+    Dispmanx layer for Raspberry PI. Default 0
   """
   if tk: #NB this happens before Display created so use_pygame will not work on linux
     if pi3d.PLATFORM != pi3d.PLATFORM_PI and pi3d.PLATFORM != pi3d.PLATFORM_ANDROID:
@@ -537,7 +539,7 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
   display.right = x + w
   display.bottom = y + h
 
-  display.opengl.create_display(x, y, w, h, depth=depth, samples=samples)
+  display.opengl.create_display(x, y, w, h, depth=depth, samples=samples, layer=layer)
   if pi3d.PLATFORM == pi3d.PLATFORM_ANDROID:
     display.width = display.right = display.max_width = display.opengl.width #not available until after create_display
     display.height = display.bottom = display.max_height = display.opengl.height

--- a/pi3d/util/DisplayOpenGL.py
+++ b/pi3d/util/DisplayOpenGL.py
@@ -43,7 +43,7 @@ class DisplayOpenGL(object):
       self.screen = xlib.XDefaultScreenOfDisplay(self.d)
       self.width, self.height = xlib.XWidthOfScreen(self.screen), xlib.XHeightOfScreen(self.screen)
 
-  def create_display(self, x=0, y=0, w=0, h=0, depth=24, samples=4):
+  def create_display(self, x=0, y=0, w=0, h=0, depth=24, samples=4, layer=0):
     self.display = openegl.eglGetDisplay(EGL_DEFAULT_DISPLAY)
     assert self.display != EGL_NO_DISPLAY
 
@@ -71,7 +71,7 @@ class DisplayOpenGL(object):
                                             EGL_NO_CONTEXT, ctypes.byref(context_attribs) )
     assert self.context != EGL_NO_CONTEXT
 
-    self.create_surface(x, y, w, h)
+    self.create_surface(x, y, w, h, layer)
 
     opengles.glDepthRangef(c_float(0.0), c_float(1.0))
     opengles.glClearColor (c_float(0.3), c_float(0.3), c_float(0.7), c_float(1.0))
@@ -95,7 +95,7 @@ class DisplayOpenGL(object):
     #opengles.glEnableClientState(GL_NORMAL_ARRAY)
     self.active = True
 
-  def create_surface(self, x=0, y=0, w=0, h=0):
+  def create_surface(self, x=0, y=0, w=0, h=0, layer=0):
     #Set the viewport position and size
     dst_rect = c_ints((x, y, w, h))
     src_rect = c_ints((x, y, w << 16, h << 16))
@@ -115,7 +115,7 @@ class DisplayOpenGL(object):
       self.dispman_element = bcm.vc_dispmanx_element_add(
         self.dispman_update,
         self.dispman_display,
-        0, ctypes.byref(dst_rect),
+        layer, ctypes.byref(dst_rect),
         0, ctypes.byref(src_rect),
         DISPMANX_PROTECTION_NONE,
         0, 0, 0)


### PR DESCRIPTION
We needed to run our OpenGL UI in a higher level to allow video playback with the UI as an overlay.
I've added the parameter to the Display.create method so now it's configurable.