### PR TITLE
Deliver X11 KeyRelease events to the display.event_queue

### DIFF
--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -307,11 +307,10 @@ class Display(object):
     elif pi3d.PLATFORM != pi3d.PLATFORM_PI and pi3d.PLATFORM != pi3d.PLATFORM_ANDROID:
       n = xlib.XEventsQueued(self.opengl.d, xlib.QueuedAfterFlush)
       for i in range(n):
-        if xlib.XCheckMaskEvent(self.opengl.d, KeyPressMask, self.ev):
-          self.event_list.append(self.ev)
-        else:
           xlib.XNextEvent(self.opengl.d, self.ev)
-          if self.ev.type == ClientMessage:
+          if self.ev.type == KeyPress or self.ev.type == KeyRelease:
+              self.event_list.append(self.ev)
+          elif self.ev.type == ClientMessage:
             if (self.ev.xclient.data.l[0] == self.opengl.WM_DELETE_WINDOW.value):
               self.destroy()
     self.clear()

--- a/pi3d/Keyboard.py
+++ b/pi3d/Keyboard.py
@@ -132,8 +132,8 @@ class x11Keyboard(object):
       self.display = Display.INSTANCE
     n = len(self.display.event_list)
     for i, e in enumerate(self.display.event_list):
-      if e.type == x.KeyPress or e.type == x.KeyRelease: #TODO not sure why KeyRelease needed!
-        self.display.event_list.pop(i)
+      self.display.event_list.pop(i)
+      if e.type == x.KeyPress:
         self.key_num = self.KEYBOARD[e.xkey.keycode][0]
         self.key_code = self.KEYBOARD[e.xkey.keycode][1]
         return True
@@ -248,4 +248,3 @@ def Keyboard(use_curses=USE_CURSES):
     return x11Keyboard()
   else:
     return CursesKeyboard() if use_curses else SysKeyboard()
-

--- a/pi3d/Keyboard.py
+++ b/pi3d/Keyboard.py
@@ -130,9 +130,8 @@ class x11Keyboard(object):
     if self.display is None: #Because DummyTkWin Keyboard instance created before Display!
       from pi3d.Display import Display
       self.display = Display.INSTANCE
-    n = len(self.display.event_list)
-    for i, e in enumerate(self.display.event_list):
-      self.display.event_list.pop(i)
+    while len(self.display.event_list) > 0:
+      e = self.display.event_list.pop(0)
       if e.type == x.KeyPress:
         self.key_num = self.KEYBOARD[e.xkey.keycode][0]
         self.key_code = self.KEYBOARD[e.xkey.keycode][1]

--- a/pi3d/util/DisplayOpenGL.py
+++ b/pi3d/util/DisplayOpenGL.py
@@ -163,7 +163,7 @@ class DisplayOpenGL(object):
       #                                min_width = 20,
       #                                min_height = 20)
 
-      xlib.XSelectInput(self.d, self.window, KeyPressMask)
+      xlib.XSelectInput(self.d, self.window, KeyPressMask | KeyReleaseMask)
       xlib.XMapWindow(self.d, self.window)
       self.surface = openegl.eglCreateWindowSurface(self.display, self.config, self.window, 0)
 


### PR DESCRIPTION
Hi again,

For our app we need to receive XKeyRelease events from the keyboard.
I understand that for most use cases this is not really necessary and that keypress events are mostly sufficient (especially with autorepeat being on on most computers), so maybe this change is not worth integrating...

Anyways I think adding them in the Display wouldn't hurt - it allows people to process press and release events if needed (overriding or patching the X11Keyboard class). At least you don't have to 
modify the Display to get the events from xlib (we had to monkeypatch Display.__loop_begin() to do this)

I've modified the x11keyboard to pop all events from the queue, but only return key codes for the press events, so it should behave the same way as before. I've checked a few of the demos on my Linux laptop and they seem to work - it actually seems to work a bit better now:
In MarsStation the player kept moving some time after I released the button, which doesn't happen after this change.
Let me know if you see an issue with this!
Thanks!