### PR TITLE
Texture formats

### DIFF
--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -223,13 +223,7 @@ class Texture(Loadable):
     if new_array is not None:
       self.image = new_array
     opengles.glBindTexture(GL_TEXTURE_2D, self._tex)
-    iformat = self.__get_format_from_array(self.image, self.i_format)
-    opengles.glTexImage2D(GL_TEXTURE_2D, 0, iformat, self.ix, self.iy, 0, iformat,
-                          GL_UNSIGNED_BYTE,
-                          self.image.ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)))
-    opengles.glEnable(GL_TEXTURE_2D)
     if self.mipmap:
-      opengles.glGenerateMipmap(GL_TEXTURE_2D)
       opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                                GL_LINEAR_MIPMAP_NEAREST)
       opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
@@ -239,6 +233,15 @@ class Texture(Loadable):
                                GL_NEAREST)
       opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
                                GL_NEAREST)
+
+    iformat = self.__get_format_from_array(self.image, self.i_format)
+    opengles.glTexImage2D(GL_TEXTURE_2D, 0, iformat, self.ix, self.iy, 0, iformat,
+                          GL_UNSIGNED_BYTE,
+                          self.image.ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)))
+    opengles.glEnable(GL_TEXTURE_2D)
+    if self.mipmap:
+      opengles.glGenerateMipmap(GL_TEXTURE_2D)
+
     opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
                              self.m_repeat)
     opengles.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,

--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -226,7 +226,7 @@ class Texture(Loadable):
     iformat = self.__get_format_from_array(self.image, self.i_format)
     opengles.glTexImage2D(GL_TEXTURE_2D, 0, iformat, self.ix, self.iy, 0, iformat,
                           GL_UNSIGNED_BYTE,
-                          self.image.ctypes.data_as(ctypes.POINTER(ctypes.c_short)))
+                          self.image.ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)))
     opengles.glEnable(GL_TEXTURE_2D)
     if self.mipmap:
       opengles.glGenerateMipmap(GL_TEXTURE_2D)

--- a/pi3d/Texture.py
+++ b/pi3d/Texture.py
@@ -151,7 +151,7 @@ class Texture(Loadable):
     if self.i_format:
       # if format is specified, convert the image accordingly
       expected_mode = FORMAT_MODES[self.i_format]
-      if im.mode != expected_mode and self.i_format != GL_LUMINANCE_ALPHA:
+      if im.mode != expected_mode:
         im = im.convert(expected_mode)
     elif im.mode not in ['RGBA', 'RGB', 'LA', 'L']:
         # other image types are converted to rgba


### PR DESCRIPTION
Hi,

These'd the changes to support the different formats - right now it chooses the format depending on the array's format - this might not be optimal (and the code still needs some error checking), but it should work both for loading a PIL image or an array directly.
All formats have a different number of channels except GL_ALPHA and GL_LUMINANCE which can be chosen using i_format.

BTW I've looked at the mipmapping part - and as it was right now memory was allocated for mipmaps even though the mipmap param was false (the filter method was set *after* loading the texture).
I'd also like to add a separate param to choose between GL_NEAREST and GL_LINEAR independent of if mipmaps are used or not (but that's for another PR).

That's the example I'm using: https://github.com/swehner/pi3d_demos/blob/test-texture-formats/TFormats.py

Memory usages on RaspberryPi with `/opt/vc/bin/vcdbg reloc` before the change (only 4 textures because the one with i_format=GL_ALPHA fails to load):
```
[  34] 0x1d324360: used 1.3M (refcount 2 lock count 1, size  1400832, align 4096, data 0x1d325000, d1rual) 'Texture blob'
[  50] 0x1d47b380: used 1.3M (refcount 2 lock count 1, size  1400832, align 4096, data 0x1d47c000, d1rual) 'Texture blob'
[  37] 0x1d5d23a0: used 1.3M (refcount 2 lock count 1, size  1400832, align 4096, data 0x1d5d3000, d1rual) 'Texture blob'
[  31] 0x1d7293c0: used 1.3M (refcount 2 lock count 1, size  1400832, align 4096, data 0x1d72a000, d1rual) 'Texture blob'
```
Memory usages on RaspberryPi with the changes:
```
[  48] 0x1d57b340: used 516K (refcount 2 lock count 1, size   524288, align 4096, data 0x1d57c000, d1rual) 'Texture blob'
[  45] 0x1d5fc360: used 1.0M (refcount 2 lock count 1, size  1048576, align 4096, data 0x1d5fd000, d1rual) 'Texture blob'
[  36] 0x1d6fd380: used 260K (refcount 2 lock count 1, size   262144, align 4096, data 0x1d6fe000, d1rual) 'Texture blob'
[  32] 0x1d73e3a0: used 1.0M (refcount 2 lock count 1, size  1048576, align 4096, data 0x1d73f000, d1rual) 'Texture blob'
[  81] 0x1d83f3c0: used 260K (refcount 1 lock count 0, size   262144, align 4096, data 0x1d840000, d1rual) 'Texture blob'
```
As you can see the allocated memory is a lot smaller - (according to number of channels except for the rgb image - maybe some memory alignment thing?) and also becaus no space for mipmaps is reserved.

Let me know what you think!
Before merging I'd like to do some more error checking on the numpy array format.
Also do you think it's be with it to convert the image format if r_format is specifide - so e.g. if you set i_format to GL_LUMINANCE and feed in an RGBA image should it convert it to L or load it as GL_RGBA?
