### PR TITLE
Add display configuration controlling frame size, style and state

### DIFF
--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -11,6 +11,7 @@ import platform
 import pi3d
 from pi3d.util import Log
 from pi3d.util.DisplayOpenGL import DisplayOpenGL
+from pi3d.constants import *
 
 if pi3d.PLATFORM == pi3d.PLATFORM_WINDOWS:
   import pygame
@@ -401,7 +402,8 @@ class Display(object):
 def create(x=None, y=None, w=None, h=None, near=None, far=None,
            fov=DEFAULT_FOV, depth=DEFAULT_DEPTH, background=None,
            tk=False, window_title='', window_parent=None, mouse=False,
-           frames_per_second=None, samples=DEFAULT_SAMPLES, use_pygame=False, layer=0):
+           frames_per_second=None, samples=DEFAULT_SAMPLES, use_pygame=False, layer=0, 
+           display_config=DISPLAY_CONFIG_DEFAULT):
   """
   Creates a pi3d Display.
 
@@ -441,8 +443,8 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
     To use pygame for display surface, mouse and keyboard - as per windows
     This almost certainly would conflict if attempting to use in combination
     with tk=True. Default False
-  *layer*
-    Dispmanx layer for Raspberry PI. Default 0
+  *display_config*
+    Configuration of display - See pi3d.constants for DISPLAY_CONFIG options
   """
   if tk: #NB this happens before Display created so use_pygame will not work on linux
     if pi3d.PLATFORM != pi3d.PLATFORM_PI and pi3d.PLATFORM != pi3d.PLATFORM_ANDROID:
@@ -538,7 +540,7 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
   display.right = x + w
   display.bottom = y + h
 
-  display.opengl.create_display(x, y, w, h, depth=depth, samples=samples, layer=layer)
+  display.opengl.create_display(x, y, w, h, depth=depth, samples=samples, layer=layer, display_config=display_config)
   if pi3d.PLATFORM == pi3d.PLATFORM_ANDROID:
     display.width = display.right = display.max_width = display.opengl.width #not available until after create_display
     display.height = display.bottom = display.max_height = display.opengl.height

--- a/pi3d/constants/__init__.py
+++ b/pi3d/constants/__init__.py
@@ -45,6 +45,14 @@ PLATFORM_ANDROID = 4
 # Force pygame if possible
 USE_PYGAME = False
 
+#Display 
+DISPLAY_CONFIG_DEFAULT = 0
+DISPLAY_CONFIG_NO_RESIZE = 1
+DISPLAY_CONFIG_NO_FRAME = 2
+DISPLAY_CONFIG_FULLSCREEN = 4
+DISPLAY_CONFIG_MAXIMIZED = 8
+
+
 # Lastly, load the libraries.
 def _load_library(name, dll_type="C"):
   """Try to load a shared library, report an error on failure."""

--- a/pi3d/util/DisplayOpenGL.py
+++ b/pi3d/util/DisplayOpenGL.py
@@ -9,6 +9,7 @@ import pi3d
 from pi3d.constants import *
 
 from pi3d.util.Ctypes import c_ints
+from pygame.constants import FULLSCREEN
 
 if pi3d.USE_PYGAME:
   import pygame
@@ -43,9 +44,11 @@ class DisplayOpenGL(object):
       self.screen = xlib.XDefaultScreenOfDisplay(self.d)
       self.width, self.height = xlib.XWidthOfScreen(self.screen), xlib.XHeightOfScreen(self.screen)
 
-  def create_display(self, x=0, y=0, w=0, h=0, depth=24, samples=4, layer=0):
+  def create_display(self, x=0, y=0, w=0, h=0, depth=24, samples=4, layer=0, display_config=DISPLAY_CONFIG_DEFAULT):
     self.display = openegl.eglGetDisplay(EGL_DEFAULT_DISPLAY)
     assert self.display != EGL_NO_DISPLAY
+    
+    self.display_config = display_config
 
     r = openegl.eglInitialize(self.display, 0, 0)
     #assert r == EGL_FALSE
@@ -131,11 +134,21 @@ class DisplayOpenGL(object):
 
     elif pi3d.USE_PYGAME:
       import pygame
-      flags = pygame.RESIZABLE | pygame.OPENGL
+      flags = pygame.OPENGL
       wsize = (w, h)
       if w == self.width and h == self.height: # i.e. full screen
-        flags = pygame.FULLSCREEN | pygame.OPENGL | pygame.NOFRAME
+        flags = pygame.FULLSCREEN | pygame.OPENGL
         wsize = (0, 0)
+      if self.display_config & DISPLAY_CONFIG_NO_RESIZE:
+        flags |= pygame.RESIZABLE
+      if self.display_config & DISPLAY_CONFIG_NO_FRAME:
+        flags |= pygame.NOFRAME
+      if self.display_config & DISPLAY_CONFIG_FULLSCREEN:
+        flags |= pygame.FULLSCREEN
+      elif self.display_config & DISPLAY_CONFIG_MAXIMIZED:
+        flags |= pygame.FULLSCREEN
+        wsize = (0, 0)
+        
       self.width, self.height = w, h
       self.d = pygame.display.set_mode(wsize, flags)
       self.window = pygame.display.get_wm_info()["window"]


### PR DESCRIPTION
Enable display frame configuration according to taste.  Operates only with pygame in this version.  It is written to be compatible with other schemes if they support it.