### PR TITLE
handle failed input event streams

### DIFF
--- a/pi3d/event/Event.py
+++ b/pi3d/event/Event.py
@@ -94,6 +94,10 @@ class InputEvents(object):
     Handle all events that have been triggered since the last call.
     """
     for event in EventStream.allNext(self.streams):
+      if event.eventType == None:
+        self.streams.remove(event.stream)
+        event.stream.release()
+        continue
       if self.handler.event(event) and self.unhandledHandler:
         self.unhandledHandler(event)
 


### PR DESCRIPTION
this is a possible way of handling failed input devices:

* in `EventStream.allNext()` remove the `fd` from `selectlist`
* in `EventStream.allNext()` `yield` an empty `EventStruct`
* in `Event.do_input_events()` check for `eventType == None`
 * remove failed `stream` from `self.streams`
 * `release()` failed `stream`

this also removes the old code where failed `fd`s where stored in a set. it also assumes a failed device will never come back.