### PR TITLE
Fix to allow for GLES shared library rename in Raspbian Stretch release

### DIFF
--- a/pi3d/constants/__init__.py
+++ b/pi3d/constants/__init__.py
@@ -95,9 +95,12 @@ def _linux():
     openegl = _load_library('/system/lib/libEGL.so')
   else:
     import os
-    if os.path.isfile('/opt/vc/lib/libGLESv2.so'): # raspbian
+    if os.path.isfile('/opt/vc/lib/libGLESv2.so'): # raspbian before stretch release
       opengles = _load_library('/opt/vc/lib/libGLESv2.so')
       openegl = _load_library('/opt/vc/lib/libEGL.so')
+    elif os.path.isfile('/opt/vc/lib/libbrcmGLESv2.so'): # raspbian after stretch release
+      opengles = _load_library('/opt/vc/lib/libbrcmGLESv2.so')
+      openegl = _load_library('/opt/vc/lib/libbrcmEGL.so')
     elif os.path.isfile('/usr/lib/libGLESv2.so'): # ubuntu MATE (but may catch others - monitor problems)
       opengles = _load_library('/usr/lib/libGLESv2.so')
       openegl = _load_library('/usr/lib/libEGL.so')


### PR DESCRIPTION
In the new "Stretch" release of Raspbian, the built-in Broadcom OpenGL ES libraries have been renamed in order to avoid clashes with the MESA version.   As pi3d isn't designed to work with MESA (https://pi3d.github.io/html/FAQ.html#glx-dri2-not-supported-or-failed-to-authenticate) then it needs to load the brcm libraries using the new names.

The proposed patch should work fine on both Jessie and Stretch.