### PR TITLE
Framing: avoid catching up lost frames when framerate drops

### DIFF
--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -383,11 +383,13 @@ class Display(object):
     for sprite in to_unload:
       sprite.unload_opengl()
 
-    if getattr(self, 'frames_per_second', 0):
-      self.time += 1.0 / self.frames_per_second
-      delta = self.time - time.time()
+    if self.frames_per_second:
+      now = time.time()
+      delta = 1. / self.frames_per_second - (now - self.time)
       if delta > 0:
         time.sleep(delta)
+
+    self.time = time.time()
 
   def _for_each_sprite(self, function, sprites=None):
     if sprites is None:

--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -384,7 +384,7 @@ class Display(object):
       sprite.unload_opengl()
 
     if self.frames_per_second:
-      delta = 1. / self.frames_per_second - (time.time() - self.time)
+      delta = 1.0 / self.frames_per_second - (time.time() - self.time)
       if delta > 0:
         time.sleep(delta)
 

--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -536,7 +536,7 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
 
   LOGGER.debug('Display size is w=%d, h=%d', w, h)
 
-  display.frames_per_second = frames_per_second
+  display.frames_per_second = frames_per_second or 0
 
   if near is None:
     near = DEFAULT_NEAR
@@ -560,10 +560,10 @@ def create(x=None, y=None, w=None, h=None, near=None, far=None,
     display.width = display.right = display.max_width = display.opengl.width #not available until after create_display
     display.height = display.bottom = display.max_height = display.opengl.height
     display.top = display.bottom = 0
-    if frames_per_second is not None:
+    if frames_per_second:
       display.android.frames_per_second = frames_per_second
-      display.frames_per_second = None #to avoid clash between two systems!
-    
+      display.frames_per_second = 0 #to avoid clash between two systems!
+
   display.mouse = None
 
   if mouse:

--- a/pi3d/Display.py
+++ b/pi3d/Display.py
@@ -384,8 +384,7 @@ class Display(object):
       sprite.unload_opengl()
 
     if self.frames_per_second:
-      now = time.time()
-      delta = 1. / self.frames_per_second - (now - self.time)
+      delta = 1. / self.frames_per_second - (time.time() - self.time)
       if delta > 0:
         time.sleep(delta)
 


### PR DESCRIPTION
Currently the way framing is implemented has 2 negative effects in case of lag:
- clock drifting
- unneeded draw calls while "catching up" lost frames

This PR proposes a simpler implementation that
- waits until next frame
- ignores lost frames
- gives Display.INSTANCE a reliable clock 

In terms of animation smoothness it doesn't hurt either, as long as Display.INSTANCE.time is used as reference for computing the animation's state. I'm already using this in my app's [main loop ](https://github.com/PlagiatBros/pytaVSL/blob/master/engine/core.py#L152).

NB: the first commit may be discarded, I just felt the `getattr` usage wasn't very pythonic.