### PR TITLE
Fixed file paths for windows DLLs

### DIFF
--- a/pi3d/constants/__init__.py
+++ b/pi3d/constants/__init__.py
@@ -151,8 +151,8 @@ def _windows():
   here http://github.com/paddywwoof/pi3d_windll
   """
   import ctypes.wintypes as wt
-  opengles = _load_library("libglesv2.dll", "Win")
-  openegl = _load_library("libegl.dll", "Win")
+  opengles = _load_library("./libglesv2.dll", "Win")
+  openegl = _load_library("./libegl.dll", "Win")
   openegl.eglGetDisplay.argtypes = [wt.HDC]
   return platform, bcm, openegl, opengles # opengles now determined by platform
 


### PR DESCRIPTION
According to the docs, the DLLs should be placed in the same directory as the project. The file paths were in the constants were not pointing there by default.