### PR TITLE
macOS apple silicon (M1) patch

### DIFF
--- a/pi3d/constants/__init__.py
+++ b/pi3d/constants/__init__.py
@@ -157,7 +157,22 @@ def _windows():
   return platform, bcm, openegl, opengles # opengles now determined by platform
 
 def _darwin():
-  pass
+  """
+  Tested on macOS for apple silicon (M1). Actual there seems no port for EGL, so only glx is supported.
+  XQuartz has to be installed and running (X11 server)
+  ensure DYLD_FALLBACK_LIBRARY_PATH is defined
+  - export DYLD_FALLBACK_LIBRARY_PATH="/opt/X11/lib" or
+  - export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib"
+  """
+  from ctypes.util import find_library
+  platform = PLATFORM_OSX
+  bcm = None
+
+  openegl = None
+  opengles_name = find_library('GLESv2.2')
+  opengles = _load_library(opengles_name)
+
+  return platform, bcm, openegl, opengles # opengles now determined by platform
 
 _PLATFORMS = {
   'linux': _linux,
@@ -173,7 +188,8 @@ def _detect_platform_and_load_libraries():
   if not loader:
     raise Exception("Couldn't understand platform %s" % platform_name)
   platform, bcm, openegl, opengles = loader()
-  set_egl_function_args(openegl) # function defined in constants/elg.py
+  if openegl != None:
+    set_egl_function_args(openegl) # function defined in constants/elg.py
   set_gles_function_args(opengles) #function defined in constants/gl.py
 
   return platform, bcm, openegl, opengles

--- a/pi3d/util/DisplayOpenGL.py
+++ b/pi3d/util/DisplayOpenGL.py
@@ -27,8 +27,8 @@ if not (pi3d.USE_PYGAME or PLATFORM in (PLATFORM_ANDROID, PLATFORM_PI, PLATFORM_
     CWBorderPixel, CWColormap, CWEventMask, EnterWindowMask, ExposureMask,
     KeyPressMask, KeyReleaseMask, LeaveWindowMask, OwnerGrabButtonMask,
     ResizeRedirectMask, StructureNotifyMask)
-
-
+    
+  
   from pyxlib import glx
   X_WINDOW = True
 else:
@@ -87,6 +87,7 @@ class DisplayOpenGL(object):
     self.display_config = display_config
     self.window_title = window_title.encode()
     if not self.use_glx:
+      assert openegl is not None # TODO implement better error handling. On macOS there is no egl, so glx has to be used.
       self.display = openegl.eglGetDisplay(EGL_DEFAULT_DISPLAY)
       assert self.display != EGL_NO_DISPLAY and self.display is not None
       for smpl in [samples, 0]: # try with samples first but ANGLE dll can't cope so drop to 0 for windows

--- a/pyxlib/glx.py
+++ b/pyxlib/glx.py
@@ -1,10 +1,14 @@
 from ctypes import (CDLL, Structure, Union, c_char, c_short, c_int, c_int64, c_uint,
     c_long, c_ulong, CFUNCTYPE, POINTER)
 from ctypes.util import find_library
+from pi3d.constants import PLATFORM, PLATFORM_OSX
 from .x import XID, VisualID, Colormap
 from pyxlib import xlib
 
-glx_name = find_library('GLX')
+if PLATFORM == PLATFORM_OSX:
+    glx_name = find_library('GL')
+else:
+    glx_name = find_library('GLX')
 libGLX = CDLL(glx_name)
 
 GLX_VERSION_1_1 = 1


### PR DESCRIPTION
Tested on macOS for apple silicon (M1). Actual there seems no port for EGL, so only glx is supported.
XQuartz has to be installed and running (X11 server)
Ensure DYLD_FALLBACK_LIBRARY_PATH is defined
  - export DYLD_FALLBACK_LIBRARY_PATH="/opt/X11/lib" or
  - export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib"